### PR TITLE
Clear out read variables so we don't accidentally count reads twice i…

### DIFF
--- a/hic_qc.py
+++ b/hic_qc.py
@@ -234,6 +234,8 @@ class HiCQC(object):
                 if read.query_name == a.query_name:
                     b = read
                     self.process_pair(a, b)
+                    a = None
+                    b = None
                 else:
                     a = read
 


### PR DESCRIPTION
Clear out read variables so we don't accidentally count reads twice if something unexpected happens regarding ordering of secondary and/or supplementary alignments, which could lead to overcounting zero-distance read pairs