### PR TITLE
Fixed issue with bad name in write_pdf_report

### DIFF
--- a/hic_qc.py
+++ b/hic_qc.py
@@ -1147,10 +1147,9 @@ class HiCQC(object):
         style_path = os.path.join(self.paths['script_dir'], "collateral", "style.css")
 
         if not os.path.exists(template_path):
-            UserWarning("Can't find markdown template at {}! Exitting...".format(
-                qc_repo_path)
+            raise FileNotFoundError("Can't find markdown template at {}! Exitting...".format(
+                template_path)
             )
-            sys.exit(1)
 
         with open(template_path) as template_fh:
             template_string = template_fh.read()

--- a/hic_qc.py
+++ b/hic_qc.py
@@ -1152,12 +1152,7 @@ class HiCQC(object):
         style_path = os.path.join(self.paths['script_dir'], "collateral", "style.css")
 
         if not os.path.exists(template_path):
-            raise FileNotFoundError("Can't find markdo
-
-            try:
-    FileNotFoundError
-except NameError:
-    FileNotFoundError = IOErrorwn template at {}! Exitting...".format(
+            raise FileNotFoundError("Can't find markdown template at {}! Exitting...".format(
                 template_path)
             )
 

--- a/hic_qc.py
+++ b/hic_qc.py
@@ -30,6 +30,11 @@ import re
 from _version import get_versions
 __version__ = get_versions()['version']
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 # default QC thresholds if there is no thresholds file
 DEFAULT_MIN_SAME_STRAND_HQ_PERCENTAGE           =   0.015
 DEFAULT_MIN_INFORMATIVE_READ_PAIRS_PERCENTAGE   =   0.05
@@ -1147,7 +1152,12 @@ class HiCQC(object):
         style_path = os.path.join(self.paths['script_dir'], "collateral", "style.css")
 
         if not os.path.exists(template_path):
-            raise FileNotFoundError("Can't find markdown template at {}! Exitting...".format(
+            raise FileNotFoundError("Can't find markdo
+
+            try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOErrorwn template at {}! Exitting...".format(
                 template_path)
             )
 

--- a/tests/test_hic_qc.py
+++ b/tests/test_hic_qc.py
@@ -449,5 +449,10 @@ class MyTestCase(unittest.TestCase):
         self.QCtmp.write_dists_file()
         self.QCtmp.write_pdf_report(quiet=True)
 
+    def test_bad_report_path(self):
+        self.QCtmp.paths["script_dir"] = "/not/a/path"
+        with self.assertRaises(FileNotFoundError):
+            self.QCtmp.write_pdf_report(quiet=True)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hic_qc.py
+++ b/tests/test_hic_qc.py
@@ -25,6 +25,11 @@ import unittest
 import hic_qc
 import pysam
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
 class MyTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(self):


### PR DESCRIPTION
This PR resolves #54 , raises an error instead of using sys.exit(), and adds a test to confirm.