### PR TITLE
Set version for pysam and matplotlib in conda create command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - if [[ "$PYTHON" == "default" ]]; then
       conda env create -n test-environment --file env.yml;
     else
-      conda create -q -n test-environment python=$PYTHON pysam numpy scipy matplotlib wkhtmltopdf pdfkit markdown;
+      conda create -q -n test-environment python=$PYTHON pysam=0.15 numpy scipy matplotlib=3.3 wkhtmltopdf pdfkit markdown;
     fi
   - source activate test-environment
   - python --version


### PR DESCRIPTION
Fixes failing build due to wrong matplotlib version, uses slightly older pysam version to avoid annoying warnings from htslib.